### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 s3deploy
 =========
 
-[![Latest Version](https://pypip.in/v/s3deploy/badge.png)](https://pypi.python.org/pypi/s3deploy/)
+[![Latest Version](https://img.shields.io/pypi/v/s3deploy.svg)](https://pypi.python.org/pypi/s3deploy/)
 [![Build Status](https://travis-ci.org/petermelias/s3deploy.svg?branch=master)](https://travis-ci.org/petermelias/s3deploy)
-[![Montly Downloads](https://pypip.in/d/s3deploy/badge.png?month)](https://pypi.python.org/pypi/s3deploy)
-[![Download format](https://pypip.in/format/s3deploy/badge.png)](https://pypi.python.org/pypi/s3deploy/)
+[![Montly Downloads](https://img.shields.io/pypi/dm/s3deploy.svg?month=)](https://pypi.python.org/pypi/s3deploy)
+[![Download format](https://img.shields.io/pypi/format/s3deploy.svg)](https://pypi.python.org/pypi/s3deploy/)
 [![Coverage Status](https://coveralls.io/repos/petermelias/s3deploy/badge.png?branch=master)](https://coveralls.io/r/petermelias/s3deploy?branch=master)
-[![License](https://pypip.in/license/s3deploy/badge.png)](https://pypi.python.org/pypi/s3deploy/)
+[![License](https://img.shields.io/pypi/l/s3deploy.svg)](https://pypi.python.org/pypi/s3deploy/)
 
 
 Deploy static sites to S3 with a single command. Efficient, fast, simple.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20s3deploy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `s3deploy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.